### PR TITLE
Google being dumb

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,22 @@
-User-agent: Google
-Disallow:
-
-User-agent: Mediapartners-Google
-Disallow:
-
-User-agent: *
+User-Agent: *
 Disallow: /
+
+User-Agent: Google
+Allow: /
+
+User-Agent: Googlebot
+Allow: /
+
+User-Agent: Googlebot-Mobile
+Allow: /
+
+User-Agent: Googlebot-Image
+Allow: /
+
+User-Agent: Mediapartners-Google
+Allow: /
+
+User-Agent: Adsbot-Google
+Allow: /
+
+Sitemap: https://thoughtcache.me/sitemap.xml


### PR DESCRIPTION
fixing robots.txt AGAIN cause google has many bots that all need access to the site and one of them that wasn't yet allowed decides to pop on by and now our site is removed from Google.

This should fix that.